### PR TITLE
feat: Add logger level to config params

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If `tag` is specified as bufferd chunk key, it send as tag for sentry.
 
 - `dsn` (required): DSN KEY shown at setting page
 - `environment` : set environment
+- `logger_level` : set log level of the sentry logger. default value is `info`
 - `default_level`: set default log level for sentry. default value is `error`
 
 ### record keys
@@ -32,9 +33,10 @@ If `tag` is specified as bufferd chunk key, it send as tag for sentry.
 
 ```aconf
 <match **>
-  @type       raven
-  dsn         https://12345678@sentry.io/123456
-  environment development
+  @type        raven
+  dsn          https://12345678@sentry.io/123456
+  logger_level warn
+  environment  development
   <buffer tag>
     @type file
     path  fluentd/log/error.*.buffer

--- a/lib/fluent/plugin/out_raven.rb
+++ b/lib/fluent/plugin/out_raven.rb
@@ -26,6 +26,7 @@ module Fluent::Plugin
 
     config_param :dsn, :string, default: nil
     config_param :environment, :string, default: nil
+    config_param :logger_level, :string, default: 'info'
     config_param :default_level, :string, default: 'error'
 
     def configure(conf)
@@ -34,6 +35,7 @@ module Fluent::Plugin
       raise Fluent::ConfigError, 'Need to Set DSN' if dsn.nil?
 
       Sentry.init do |config|
+        config.logger.level = logger_level
         config.dsn = dsn
         config.environment = environment
       end


### PR DESCRIPTION
fluent-plugin-raven can't configure log level of logger.
Adding logger_level to config parameters.