### PR TITLE
Fix for some unnessesary records

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,5 @@
 name: Test
 on:
-  - push
   - pull_request
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If `tag` is specified as bufferd chunk key, it send as tag for sentry.
 
 ### record keys
 
-- `message`: message body for sentry as events.
+- `message` (required): message body for sentry as events.
 - `level`: log level for sentry as events.
 
 


### PR DESCRIPTION
## Updates

- Sentry require environment, so set default value
- No `message` record would be filtered
- set worker as hostname if no woker at record
- stop support Ruby 2.5